### PR TITLE
Fix on cert files, mijnapp docker repository and helm installation files

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 BRANCH_NAME=local
 DOCKER_REGISTRY=docker.io/mijnapp
-APP_ENV=dev
+APP_ENV=Release

--- a/.env
+++ b/.env
@@ -1,1 +1,3 @@
 BRANCH_NAME=local
+DOCKER_REGISTRY=docker.io/mijnapp
+APP_ENV=dev

--- a/MijnApp-Backend/Dockerfile
+++ b/MijnApp-Backend/Dockerfile
@@ -14,9 +14,8 @@ RUN dotnet build "MijnApp-Backend.csproj" -c Release -o /app/build
 
 FROM build AS publish
 RUN dotnet publish "MijnApp-Backend.csproj" -c Release -o /app/publish
-
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
-COPY --from=publish /app/cert /cert
+COPY MijnApp-Backend/cert cert/
 ENTRYPOINT ["dotnet", "MijnApp-Backend.dll"]

--- a/MijnApp-Frontend/Dockerfile
+++ b/MijnApp-Frontend/Dockerfile
@@ -13,9 +13,8 @@ RUN dotnet build "MijnApp-Frontend.csproj" -c Release -o /app/build
 
 FROM build AS publish
 RUN dotnet publish "MijnApp-Frontend.csproj" -c Release -o /app/publish
-
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
-COPY --from=publish /app/cert /cert
+COPY  MijnApp-Frontend/cert cert/
 ENTRYPOINT ["dotnet", "MijnApp-Frontend.dll"]

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -21,6 +21,7 @@ services:
     ports:
       - "40080:80"
       - "40443:443"
+      
   mijnapp-frontend:
     container_name: mijnapp-frontend
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,13 +2,13 @@ version: '3.4'
 
 services:
   mijnapp-backend:
-    image: ${DOCKER_REGISTRY-}mijnappbackend_${BRANCH_NAME}
+    image: ${DOCKER_REGISTRY}/backend:${APP_ENV}
     build:
       context: .
       dockerfile: MijnApp-Backend/Dockerfile
 
   mijnapp-frontend:
-    image: ${DOCKER_REGISTRY-}mijnappfrontend_${BRANCH_NAME}
+    image: ${DOCKER_REGISTRY}/frontend:${APP_ENV}
     build:
       context: .
       dockerfile: MijnApp-Frontend/Dockerfile

--- a/helm/.helmignore
+++ b/helm/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+appVersion: V.0.1
+description: 'Mijnapp is an opensource application for communication between citizens and the municipality'
+name: mijnapp
+version: 0.1.0
+home: https://mijn-app.io/inwoner/index.html
+icon: https://mijn-app.io/inwoner/index.html

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,0 +1,3 @@
+# Deploying to a Kubernetes Cluster
+
+Conduction will write a shot instruction here

--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -1,0 +1,5 @@
+API deployed.
+
+To get the ingress's IP:
+
+    kubectl --namespace {{ .Release.Namespace }} get ingress -o jsonpath="{.items[0].status.loadBalancer.ingress[0].ip}"

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -1,0 +1,27 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "postgresql.fullname" -}}
+{{- printf "%s-%s" .Release.Name "postgresql" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/helm/templates/backend-deployment.yaml
+++ b/helm/templates/backend-deployment.yaml
@@ -1,0 +1,62 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ include "name" . }}-backend
+  labels:
+    app.kubernetes.io/name: {{ include "name" . }}-backend
+    app.kubernetes.io/part-of: {{ include "name" . }}
+    helm.sh/chart: {{ include "chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "name" . }}-backend
+        app.kubernetes.io/part-of: {{ include "name" . }}
+        helm.sh/chart: {{ include "chart" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+    spec:
+      containers:
+        - name: {{ include "name" . }}-backend
+          image: "docker.io/mijnapp/backend:{{ .Values.settings.env }}"
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 80
+            - containerPort: 443
+          env:
+            - name: ASPNETCORE_ENVIRONMENT
+              value: Release
+            - name: ASPNETCORE_URLS
+              value: https://+:443;http://+:80
+            - name: ASPNETCORE_HTTPS_PORT
+              value: 443
+            - name: ASPNETCORE_Kestrel__Certificates__Default__Path
+              value: /app/cert/test.pfx
+            - name: ASPNETCORE_Kestrel__Certificates__Default__Password
+              value: MyPassword
+            - name: ORIGINS
+              value: https://localhost:60443
+            - name: JwtClaimEncryption__SecretKey
+              value: 1234567890ABCDEF
+            - name: JwtClaimEncryption__SecretKey
+              value: 1234567890ABCDEF
+            - name: Jwt__Key
+              value: df32d6192fdf2907dfe14f2c42e7316505236350a4c35195c1bbd4159360b90a
+            - name: Jwt__Issuer
+              value: MijnApp
+            - name: Jwt__Issuer
+              value: DigidCgi__SharedSecret
+            - name: DigidCgi__SiamServer
+              value: https://siam1.test.anoigo.nl/aselectserver/server
+            - name: DigidCgi__ApplicationId
+              value: SOLV_DD
+            - name: DigidCgi__SiamServerName
+              value: siam1.test.anoigo.nl
+            - name: HasFakeLoginEnabled
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "fullname" . }}
+                  key: HasFakeLoginEnabled

--- a/helm/templates/backend-service.yaml
+++ b/helm/templates/backend-service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "name" . }}-backend
+  labels:
+    app.kubernetes.io/name: {{ include "name" . }}-backend
+    app.kubernetes.io/part-of: {{ include "name" . }}
+    helm.sh/chart: {{ include "chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 80
+      protocol: TCP
+    - port: 443
+      targetPort: 443
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: {{ include "name" . }}-backend
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/helm/templates/cert-issuer.yaml
+++ b/helm/templates/cert-issuer.yaml
@@ -1,0 +1,16 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: ClusterIssuer
+metadata:
+  name: {{ include "name" . }}-{{ .Values.settings.env }}-letsencrypt
+spec:
+  acme:
+    email: {{ .Values.settings.email }}
+    http01: {}
+    privateKeySecretRef:
+      name: letsencrypt-private-key
+    server: https://acme-v02.api.letsencrypt.org/directory
+    solvers:
+    - selector: {}
+      http01:
+        ingress:
+          class: nginx

--- a/helm/templates/certificate.yaml
+++ b/helm/templates/certificate.yaml
@@ -1,0 +1,24 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: {{ include "name" . }}-{{ .Values.settings.env }}-cert
+spec:
+  secretName: {{ include "name" . }}-{{ .Values.settings.env }}-cert
+  duration: 24h
+  renewBefore: 12h
+  dnsNames:
+#  {{- if eq .Values.settings.env "prod" }}
+#  - {{ .Values.settings.name }}.{{ .Values.settings.domain }}    
+#  {{- else }}      
+#  - {{ .Values.settings.name }}.{{ .Values.settings.env }}.{{ .Values.settings.domain }}    
+#  {{- end }}
+{{- range  .Values.settings.domains  }}
+  {{- if eq $.Values.settings.env "prod" }}
+    - {{ $.Values.settings.name }}.{{ . }}
+  {{- else }}      
+  - {{ $.Values.settings.name }}.{{ $.Values.settings.env }}.{{ . }}    
+  {{- end }}
+{{- end }}
+  issuerRef:
+    name: {{ include "name" . }}-{{ .Values.settings.env }}-letsencrypt
+    kind: ClusterIssuer

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "fullname" . }}
+  #namespace: {{ .Values.settings.env }}
+  labels:
+    app.kubernetes.io/name: {{ include "name" . }}
+    app.kubernetes.io/part-of: {{ include "name" . }}
+    helm.sh/chart: {{ include "chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  adres-endpoint: {{ .Values.settings.adresEndpoint | quote }}
+  order-endpoint: {{ .Values.settings.orderEndpoint | quote }}
+  brp-endpoint: {{ .Values.settings.brpEndpoint | quote }}
+  verzoeken-endpoint: {{ .Values.settings.verzoekenEndpoint | quote }}
+  verzoekType-endpoint: {{ .Values.settings.verzoekTypeEndpoint | quote }}
+  processType-endpoint: {{ .Values.settings.processTypeEndpoint | quote }}

--- a/helm/templates/frontend-deployment.yaml
+++ b/helm/templates/frontend-deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ include "name" . }}-frontend
+  labels:
+    app.kubernetes.io/name: {{ include "name" . }}-frontend
+    app.kubernetes.io/part-of: {{ include "name" . }}
+    helm.sh/chart: {{ include "chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "name" . }}-frontend
+        app.kubernetes.io/part-of: {{ include "name" . }}
+        helm.sh/chart: {{ include "chart" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+    spec:
+      containers:
+        - name: {{ include "name" . }}-frontend
+          image: "docker.io/mijnapp/frontend:{{ .Values.settings.env }}"
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 80
+            - containerPort: 443
+          env:
+            - name: ASPNETCORE_ENVIRONMENT
+              value: Release
+            - name: ASPNETCORE_URLS
+              value: https://+:443;http://+:80
+            - name: ASPNETCORE_HTTPS_PORT
+              value: 443
+            - name: ASPNETCORE_Kestrel__Certificates__Default__Path
+              value: /app/cert/test.pfx
+            - name: ASPNETCORE_Kestrel__Certificates__Default__Password
+              value: MyPassword
+            - name: PublicSettings__BACKEND_URL
+              value: mijnapp-backend
+            - name: PublicSettings__HAS_FAKE_INLOG_ENABLED
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "fullname" . }}
+                  key: HasFakeLoginEnabled

--- a/helm/templates/frontend-service.yaml
+++ b/helm/templates/frontend-service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "name" . }}-frontend
+  labels:
+    app.kubernetes.io/name: {{ include "name" . }}-frontend
+    app.kubernetes.io/part-of: {{ include "name" . }}
+    helm.sh/chart: {{ include "chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: NodePort
+  ports:
+    - port: 80
+      targetPort: 80
+      protocol: TCP
+    - port: 443
+      targetPort: 443
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: {{ include "name" . }}-frontend
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -1,0 +1,40 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    # add an annotation indicating the issuer to use.
+    cert-manager.io/acme-challenge-type: http01
+    cert-manager.io/cluster-issuer: {{ include "name" . }}-{{ .Values.settings.env }}-letsencrypt
+  name: {{ include "name" . }}-{{ .Values.settings.env }}-ingress
+  labels:
+    app.kubernetes.io/name: {{ include "name" . }}-ingress
+    app.kubernetes.io/part-of: {{ include "name" . }}
+    helm.sh/chart: {{ include "chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  tls: 
+  - hosts: 
+  {{- range  .Values.settings.domains  }}
+    - {{ . }}
+  {{- end }}
+#    - {{ .Values.settings.domain }}
+    secretName: {{ include "name" . }}-{{ .Values.settings.env }}-cert
+  rules:
+  {{- range  .Values.settings.domains  }}
+    {{- if eq $.Values.settings.env "prod" }}
+      -   host: {{ $.Values.settings.name }}.{{ . }}
+          http:
+              paths:
+                      - backend:
+                          serviceName: {{ $.Values.settings.name }}
+                          servicePort: 80            
+    {{- else }}      
+    - host: {{ $.Values.settings.name }}.{{ $.Values.settings.env }}.{{ . }}
+      http:
+        paths:
+          - backend:
+              serviceName: {{ $.Values.settings.name }}
+              servicePort: 80
+     {{- end }}
+  {{- end }}

--- a/helm/templates/secrets.yaml
+++ b/helm/templates/secrets.yaml
@@ -1,0 +1,14 @@
+{{- $postgresqlServiceName := include "postgresql.fullname" . -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "name" . }}
+    app.kubernetes.io/part-of: {{ include "name" . }}
+    helm.sh/chart: {{ include "chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+type: Opaque
+data:
+  HasFakeLoginEnabled: {{ .Values.settings.HasFakeLoginEnabled | quote }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,0 +1,25 @@
+# Default values for api.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+settings:
+  adresEndpoint: https://adressen.zaakonline.nl/
+  orderEndpoint: https://orc.zaakonline.nl/
+  brpEndpoint: https://brp.zaakonline.nl/
+  verzoekenEndpoint: https://vrc.zaakonline.nl/
+  verzoekTypeEndpoint: https://vtc.zaakonline.nl/
+  processTypeEndpoint: https://ptc.zaakonline.nl/
+  HasFakeLoginEnabled: true
+  env: Release
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi


### PR DESCRIPTION
This pull adds the following functionality from the mijn-app conduction repository:

**Fix on the copying of cert files in docker compose**

**Mijn-app docker repository**, it is now posible to upload the build images to https://hub.docker.com/repository/docker/mijnapp/frontend and https://hub.docker.com/repository/docker/mijnapp/backend with the docker-compose push command

**Helm installation file's** We will include an tutorial at a later date but these files provide the option to install mijn-app to a kubernetes enviroment